### PR TITLE
Changelog as release notes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,3 @@
+## Version 1.0.0
+### Updates
+- Updated to React Bootstrap 4

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "check-disk-space": "^1.5.0",
-    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:^3.1.0",
+    "pc-nrfconnect-devdep": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-devdep.git#semver:3.3.0",
     "pretty-bytes": "^5.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
This is part of [NCP-2820](https://projecttools.nordicsemi.no/jira/browse/NCP-2820). The whole concept is described there.

This changes two things:
- It adds a `Changelog.md` which contains all entries that were previously in the GitHub releases.
- It references devdep 3.3 so that future releases of this app will also upload the `Changelog.md` to developer.nordicsemi.com.

Because this changes depends on the release of devdep 3.3, this PR is created as a draft PR and  will be marked as being ready later when NordicSemiconductor/pc-nrfconnect-devdep#26 is merged and devdep 3.3 is released.