### PR TITLE
Harden against new serialport version

### DIFF
--- a/lib/actions/deviceActions.js
+++ b/lib/actions/deviceActions.js
@@ -108,7 +108,10 @@ export function open(serialPort) {
     return async dispatch => {
         await dispatch(close());
 
-        port = new SerialPort(serialPort.comName, {
+        // Prefer to use the serialport 8 property or fall back to the serialport 7 property
+        const portPath = serialPort.path || serialPort.comName;
+
+        port = new SerialPort(portPath, {
             baudRate: 1000000,
             parity: 'none',
             dataBits: 8,
@@ -133,7 +136,7 @@ export function open(serialPort) {
             return;
         }
         logger.info('Device opened');
-        dispatch(deviceOpenedAction(serialPort.comName));
+        dispatch(deviceOpenedAction(portPath));
 
         dispatch(diskSpaceCheck());
         diskspaceInterval = setInterval(() => {


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

This enables the app to run with either serialport 7 (which had comName as a property) or serialport 8 (which moved to the property path and warns when still using comName).