### PR TITLE
Filter out devices without serialport that cause crash

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Versio 1.0.7
+### Fixes
+- Filtered out devices without serialport that caused crash #28
+
 ## Version 1.0.6
 ### Updates
 - Updated auto device filter for macOS #25

--- a/index.jsx
+++ b/index.jsx
@@ -68,7 +68,6 @@ const portPath = serialPort => serialPort.path || serialPort.comName;
  */
 export const config = {
     selectorTraits: {
-        jlink: true,
         serialport: true,
     },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pc-nrfconnect-tracecollector",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Capture modem trace of nRF91",
   "displayName": "Trace Collector",
   "repository": {


### PR DESCRIPTION
This PR is the same fix as for link monitor: https://github.com/NordicSemiconductor/pc-nrfconnect-linkmonitor/pull/49
Connecting a device like JLink mini which has no serialport crashes the device filtering, but such devices should not be enumerated anyway.