### PR TITLE
Remove outdated lint-init script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "dev": "nrfconnect-scripts build-watch",
     "webpack": "nrfconnect-scripts build-dev",
     "build": "nrfconnect-scripts build-prod",
-    "lint-init": "nrfconnect-scripts lint-init",
     "lint": "nrfconnect-scripts lint lib index.jsx",
     "lintfix": "nrfconnect-scripts lint --fix lib index.jsx",
     "nordic-publish": "nrfconnect-scripts nordic-publish",

--- a/package.json
+++ b/package.json
@@ -1,52 +1,52 @@
 {
-  "name": "pc-nrfconnect-tracecollector",
-  "version": "1.1.2",
-  "description": "Capture modem trace of nRF91",
-  "displayName": "Trace Collector",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector.git"
-  },
-  "author": "Nordic Semiconductor ASA",
-  "license": "SEE LICENSE IN LICENSE",
-  "engines": {
-    "nrfconnect": "^3.8.0"
-  },
-  "main": "dist/bundle.js",
-  "files": [
-    "dist/",
-    "resources/icon.*",
-    "LICENSE"
-  ],
-  "scripts": {
-    "dev": "nrfconnect-scripts build-watch",
-    "webpack": "nrfconnect-scripts build-dev",
-    "build": "nrfconnect-scripts build-prod",
-    "lint": "nrfconnect-scripts lint lib index.jsx",
-    "lintfix": "nrfconnect-scripts lint --fix lib index.jsx",
-    "nordic-publish": "nrfconnect-scripts nordic-publish",
-    "test": "nrfconnect-scripts test",
-    "test-watch": "nrfconnect-scripts test --watch",
-    "clean": "npm run clean-dist && npm run clean-modules",
-    "clean-dist": "rimraf dist",
-    "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
-  },
-  "devDependencies": {
-    "check-disk-space": "^1.5.0",
-    "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.5.4",
-    "pretty-bytes": "^5.1.0",
-    "react": "17.0.2",
-    "react-dom": "17.0.2",
-    "react-redux": "7.2.5"
-  },
-  "dependencies": {
-    "electron-store": "^3.0.0"
-  },
-  "bundledDependencies": [
-    "electron-store"
-  ],
-  "eslintConfig": {
-    "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
-  },
-  "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js"
+    "name": "pc-nrfconnect-tracecollector",
+    "version": "1.1.2",
+    "description": "Capture modem trace of nRF91",
+    "displayName": "Trace Collector",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector.git"
+    },
+    "author": "Nordic Semiconductor ASA",
+    "license": "SEE LICENSE IN LICENSE",
+    "engines": {
+        "nrfconnect": "^3.8.0"
+    },
+    "main": "dist/bundle.js",
+    "files": [
+        "dist/",
+        "resources/icon.*",
+        "LICENSE"
+    ],
+    "scripts": {
+        "dev": "nrfconnect-scripts build-watch",
+        "webpack": "nrfconnect-scripts build-dev",
+        "build": "nrfconnect-scripts build-prod",
+        "lint": "nrfconnect-scripts lint lib index.jsx",
+        "lintfix": "nrfconnect-scripts lint --fix lib index.jsx",
+        "nordic-publish": "nrfconnect-scripts nordic-publish",
+        "test": "nrfconnect-scripts test",
+        "test-watch": "nrfconnect-scripts test --watch",
+        "clean": "npm run clean-dist && npm run clean-modules",
+        "clean-dist": "rimraf dist",
+        "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\""
+    },
+    "devDependencies": {
+        "check-disk-space": "^1.5.0",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.5.4",
+        "pretty-bytes": "^5.1.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
+        "react-redux": "7.2.5"
+    },
+    "dependencies": {
+        "electron-store": "^3.0.0"
+    },
+    "bundledDependencies": [
+        "electron-store"
+    ],
+    "eslintConfig": {
+        "extends": "./node_modules/pc-nrfconnect-shared/config/eslintrc.json"
+    },
+    "prettier": "./node_modules/pc-nrfconnect-shared/config/prettier.config.js"
 }


### PR DESCRIPTION
`lint-init` is not needed anymore. Remove the last reference to it.