### PR TITLE
doc: update docs with deprecation info

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,5 +1,8 @@
 # nRF Connect Trace Collector
 
+!!! tip "Important"
+     nRF Connect Trace Collector is **deprecated** as of version [1.1.5](https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector/blob/main/Changelog.md), released on June 19, 2023. This means that the application is not being actively developed. Use [nRF Connect Cellular Monitor](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html) instead, which integrates the features of Trace Collector.
+
 nRF Connect Trace Collector is a cross-platform tool to capture trace files of the nRF9160 modem.
 
 The tool collects Universal Asynchronous Receiver/Transmitter (UART) traces from the nRF9160 System in Package (SiP) over the serial port. If you run into problems when developing and debugging your application, Nordic Semiconductor's support team might ask you to provide these binary trace files to analyze the communication between the device and the LTE network.

--- a/doc/docs/revision_history_tc.md
+++ b/doc/docs/revision_history_tc.md
@@ -2,6 +2,7 @@
 
 | Date       | Description                                                  |
 | ---------- | ------------------------------------------------------------ |
+| 2024-01-11 | Updated with the deprecation note on the [Home page](./index.md). The [Cellular Monitor](https://docs.nordicsemi.com/bundle/nrf-connect-cellularmonitor/page/index.html) application replaced Trace Collector as of version [1.1.5](https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector/blob/main/Changelog.md), released on June 19, 2023.  |
 | 2022-09-27 | Added instructions for tracing on a custom board             |
 | 2022-09-06 | Updated images and text for new user interface in nRF Connect Programmer v1.1.2 |
 | 2022-02-21 | Updated [Preparing the board for trace collection](nrf9160_preparing.md) and [Enabling tracing in the application](nrf9160_enabling.md) |

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -73,4 +73,4 @@ nav:
     - Preparing the board for trace collection: custom_preparing.md
     - Enabling tracing in the application: custom_enabling.md
     - Capturing the modem trace: custom_capturing.md
-  - Revision history: revision_history.md
+  - Revision history: revision_history_tc.md


### PR DESCRIPTION
Added a deprecation note on the home page.
Updated revision history.
NCD-650.