### PR TITLE
doc: update Infocenter links

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 1.1.6 - UNRELEASED
+
+### Changed
+
+-   Updated documentation links to point to the TechDocs platform.
+
 ## 1.1.5 - 2023-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ nRF91.
 
 ## Installation
 
-nRF Connect Trace Collector is installed from nRF Connect from Desktop. For detailed
-steps, see
+nRF Connect Trace Collector is installed from nRF Connect from Desktop. For
+detailed steps, see
 [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
 in the nRF Connect from Desktop documentation.
 

--- a/README.md
+++ b/README.md
@@ -3,16 +3,17 @@
 [![Build Status](https://dev.azure.com/NordicSemiconductor/Wayland/_apis/build/status/pc-nrfconnect-tracecollector?branchName=main)](https://dev.azure.com/NordicSemiconductor/Wayland/_build/latest?definitionId=16&branchName=main)
 [![License](https://img.shields.io/badge/license-Modified%20BSD%20License-blue.svg)](LICENSE)
 
-_nRF Connect Trace Collector_ is a cross-platform tool to capture modem trace of
+nRF Connect Trace Collector is a cross-platform tool to capture modem trace of
 nRF91.
 
 ![screenshot](resources/screenshot.gif)
 
 ## Installation
 
-See the
-[InfoCenter](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fstruct_nrftools%2Fstruct%2Fnrftools_nrfconnect.html)
-pages for information on how to install the application.
+nRF Connect Trace Collector is installed from nRF Connect from Desktop. For detailed
+steps, see
+[Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html)
+in the nRF Connect from Desktop documentation.
 
 ## Development
 
@@ -28,7 +29,7 @@ Please report issues on the [DevZone](https://devzone.nordicsemi.com) portal.
 ## Contributing
 
 See the
-[infos on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
+[information on contributing](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/contributing)
 for details.
 
 ## License

--- a/doc/docs/revision_history_tc.md
+++ b/doc/docs/revision_history_tc.md
@@ -8,9 +8,3 @@
 | 2022-02-21 | Updated [Preparing the board for trace collection](nrf9160_preparing.md) and [Enabling tracing in the application](nrf9160_enabling.md) |
 | 2021-07-07 | Updated [Preparing the board for trace collection](nrf9160_preparing.md)             |
 | 2021-04-23 | First release                                                |
-
-## Previous versions
-
-PDF files for relevant previous versions are available here:
-
-- [nRF Connect Trace Collector User Guide v1.0.7](https://infocenter.nordicsemi.com/pdf/nRF_Connect_Trace_Collector_User_Guide_v1.0.7.pdf) (corresponds to nRF Connect Trace Collector v1.0.7)

--- a/lib/components/DocumentationSections.jsx
+++ b/lib/components/DocumentationSections.jsx
@@ -10,10 +10,10 @@ import { DocumentationSection } from 'pc-nrfconnect-shared';
 const DocumentationSections = [
     <DocumentationSection
         key="infocenter"
-        linkLabel="Go to Infocenter"
-        link="https://infocenter.nordicsemi.com/topic/ug_trace_collector/UG/trace_collector/intro.html"
+        linkLabel="Go to TechDocs"
+        link="https://docs.nordicsemi.com/bundle/nrf-connect-tracecollector/page/index.html"
     >
-        Visit our Infocenter for more documentation about using the app.
+        Visit our Technical Documentation for more documentation about using the app.
     </DocumentationSection>,
 ];
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-tracecollector",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "displayName": "Trace Collector",
     "description": "Deprecated: Capture nRF91 modem trace",
     "homepage": "https://github.com/NordicSemiconductor/pc-nrfconnect-tracecollector",


### PR DESCRIPTION
Replaced Infocenter links with TechDocs ones.